### PR TITLE
Implement unit tests for common package

### DIFF
--- a/common/common_test.go
+++ b/common/common_test.go
@@ -1,0 +1,83 @@
+package common
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type ErrorRequestGenerator struct{}
+
+func (g *ErrorRequestGenerator) GenerateRequest() (*http.Request, error) {
+	return nil, errors.New("cannot create request")
+}
+
+type InvalidRequestGenerator struct{}
+
+func (g *InvalidRequestGenerator) GenerateRequest() (*http.Request, error) {
+	return http.NewRequest("POST", "invalid_address", nil)
+}
+
+type ErrorStatusGenerator struct {
+	TsServer *httptest.Server
+}
+
+func (g *ErrorStatusGenerator) GenerateRequest() (*http.Request, error) {
+	return http.NewRequest("POST", g.TsServer.URL, nil)
+}
+
+type SuccessRequestGenerator struct {
+	TsServer *httptest.Server
+}
+
+func (g *SuccessRequestGenerator) GenerateRequest() (*http.Request, error) {
+	return http.NewRequest("POST", g.TsServer.URL, nil)
+}
+
+func TestHTTPRequestToNode(t *testing.T) {
+	fmt.Println("Emit error when generating request")
+	errorRequest := &ErrorRequestGenerator{}
+	responseBody, err := HTTPRequestToNode(errorRequest)
+	assert.Error(t, err)
+	assert.Nil(t, responseBody)
+
+	fmt.Println("Send request to broken node")
+	invalidRequest := &InvalidRequestGenerator{}
+	responseBody, err = HTTPRequestToNode(invalidRequest)
+	assert.Error(t, err)
+	assert.Nil(t, responseBody)
+
+	fmt.Println("Server response error status code")
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	})
+	errorStatusRequest := &ErrorStatusGenerator{
+		TsServer: httptest.NewServer(handler),
+	}
+	responseBody, err = HTTPRequestToNode(errorStatusRequest)
+	assert.Error(t, err)
+	assert.Nil(t, responseBody)
+	assert.Equal(t, "error status code", err.Error()) // TODO: better create error type in common
+	errorStatusRequest.TsServer.Close()
+
+	fmt.Println("Success request to node")
+	handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprint(w, `{"result": "success"}`)
+	})
+	successRequest := &SuccessRequestGenerator{
+		TsServer: httptest.NewServer(handler),
+	}
+	responseBody, err = HTTPRequestToNode(successRequest)
+	assert.NoError(t, err)
+	response := map[string]string{}
+	err = json.NewDecoder(responseBody).Decode(&response)
+	assert.NoError(t, err)
+	assert.Contains(t, response, "result")
+	assert.Equal(t, "success", response["result"])
+}

--- a/common/ethereum_helper.go
+++ b/common/ethereum_helper.go
@@ -7,7 +7,7 @@ import (
 )
 
 // RequestEthereumBody structure for body request to node
-// TODO: use easyjson
+// TODO: use easyjson in future
 type RequestEthereumBody struct {
 	Params  interface{} `json:"params"`
 	Address string      `json:"-"`
@@ -31,5 +31,5 @@ func (r *RequestEthereumBody) GenerateRequest() (*http.Request, error) {
 		return nil, err
 	}
 
-	return http.NewRequest("POST", r.Address, bytes.NewBuffer(buf.Bytes()))
+	return http.NewRequest("POST", r.Address, buf)
 }

--- a/common/ethereum_helper_test.go
+++ b/common/ethereum_helper_test.go
@@ -1,0 +1,29 @@
+package common
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TODO: implement codecov for all unit tests
+func TestGenerateRequest(t *testing.T) {
+	fmt.Println("Generate success request")
+	rawRequest := &RequestEthereumBody{
+		Params:  []interface{}{"param1", "param2", "param3"},
+		Address: "http://google.com",
+		JSONRPC: "2.0",
+		Method:  "Steal_personal_data",
+		ID:      1,
+	}
+	request, err := rawRequest.GenerateRequest()
+	assert.NoError(t, err)
+	assert.Equal(t, "POST", request.Method)
+	requestBody := &RequestEthereumBody{}
+	err = json.NewDecoder(request.Body).Decode(requestBody)
+	assert.NoError(t, err)
+	rawRequest.Address = "" // because 'Address' not participating in serialize/deserialize JSON
+	assert.Equal(t, rawRequest, requestBody)
+}


### PR DESCRIPTION
Implement:
- [x] unit tests for `HTTPRequestToNode` function
- [x] unit tests for `GenerateRequest`

Refactor:
- [x] remove useless `NewBuffer` from `GenerateRequest(...)` function